### PR TITLE
Fix zoom extent on landcover dataset

### DIFF
--- a/datasets/bangladesh-landcover-2001-2020.data.mdx
+++ b/datasets/bangladesh-landcover-2001-2020.data.mdx
@@ -18,7 +18,7 @@ layers:
     type: raster
     description: 'Annual land cover maps for 2001 and 2020 (Bangladesh)'
     zoomExtent:
-      - 6
+      - 3
       - 20
     sourceParams:
       resampling_method: nearest


### PR DESCRIPTION
## What am I changing and why

Fixes zoom extent on landcover dataset, to allow data to be visible from lower zoom levels. #183

New minimum zoom level: 
![image](https://user-images.githubusercontent.com/19193384/212772314-e36b1407-bb88-403a-a62c-527dc03c495c.png)

Old behaviour (from linked issue): 
![image](https://user-images.githubusercontent.com/19193384/212772330-c138fb16-8244-4fd0-9636-963d1c1d5d7b.png)


## How to test

Relevant dataset view is at `/eis/datasets/bangladesh-landcover-2001-2020/explore?position=91.5954|23.3432|6.13&datetime=2020-01-01T00%3A00%3A00.000Z`

## ⚠️ Checks

- [x] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.