### PR TITLE
Fix thematic area for hurricane Maria story

### DIFF
--- a/discoveries/hurricane-maria-and-ida.discoveries.mdx
+++ b/discoveries/hurricane-maria-and-ida.discoveries.mdx
@@ -9,6 +9,7 @@ media:
   alt: Nighttime view of New Orleans
 thematics:
   - environmental-justice
+  - covid-19
 ---
 
 <style>{`

--- a/discoveries/hurricane-maria-and-ida.discoveries.mdx
+++ b/discoveries/hurricane-maria-and-ida.discoveries.mdx
@@ -1,6 +1,6 @@
 ---
 featuredOn:
-  - covid-19
+  - environmental-justice
 id: "hurricane-maria-and-ida"
 name: Connecting Disaster Recovery with Environmental Justice
 description: "Featuring Hurricane María and Hurricane Ida"
@@ -9,7 +9,6 @@ media:
   alt: Nighttime view of New Orleans
 thematics:
   - environmental-justice
-  - covid-19
 ---
 
 <style>{`


### PR DESCRIPTION
## What am I changing and why

Hurricane maria discovery is featured on the thematic area that it doesn't belong to, which makes URL like this: https://www.earthdata.nasa.gov/dashboard/covid-19/discoveries/hurricane-maria-and-ida. (Link from the main page.)

## How to test
Go to /covid-19/discoveries/hurricane-maria-and-ida and check if the link returns the discovery. 