### PR TITLE
Add GTM related env vars to action

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build production
         env:
           MAPBOX_TOKEN: ${{secrets.MAPBOX_TOKEN}}
+          GOOGLE_TAG_MANAGER_ID: ${{secrets.GOOGLE_TAG_MANAGER_ID}}
+          GOOGLE_TAG_AUTH: ${{secrets.GOOGLE_TAG_AUTH}}
+          GOOGLE_TAG_PREVIEW: ${{secrets.GOOGLE_TAG_PREVIEW}}
         run: PUBLIC_URL="${{ env.DOMAIN_PROD }}" yarn build
 
   deploy:


### PR DESCRIPTION
## What am I changing and why
I forgot to pass GTM related variables set up in GitHub to action in https://github.com/NASA-IMPACT/veda-config/pull/200 Mind that I didn't include these variables in staging github action to separate the variables for production from the ones for staging.

## How to test
There is really no good way to test this.

## ⚠️ Checks

- [ ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.