### PR TITLE
add nbgitpuller links for datasets

### DIFF
--- a/datasets/mo_npp_vgpm.data.mdx
+++ b/datasets/mo_npp_vgpm.data.mdx
@@ -2,6 +2,13 @@
 id: npp
 name: "Ocean Net Primary Production"
 description: "Ocean Net Primary Production (NPP)"
+usage:
+  - url: 'https://github.com/NASA-IMPACT/veda-docs/blob/main/example-notebooks/ocean-npp-timeseries-analysis.ipynb'
+    label: View example notebook
+    title: 'Static view in VEDA documentation'
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FNASA-IMPACT%2Fveda-docs&branch=main&urlpath=lab%2Ftree%2Fveda-docs%2Fexample-notebooks%2Focean-npp-timeseries-analysis.ipynb"
+    label: Run example notebook
+    title: 'Interactive session in VEDA 2i2c JupyterHub (requires account)'
 media:
   src: ::file ./ocean-production--dataset-cover.jpg
   alt: Rocky ocean shore

--- a/datasets/nceo_africa_2017.data.mdx
+++ b/datasets/nceo_africa_2017.data.mdx
@@ -1,7 +1,14 @@
 ---
 id: nceo_africa_2017
 name: "National Centre for Earth Observation (NCEO) Biomass"
-description: The NCEO Africa Aboveground Woody Biomass (AGB) map for the year 2017 at 100 m spatial resolution 
+description: The NCEO Africa Aboveground Woody Biomass (AGB) map for the year 2017 at 100 m spatial resolution
+usage:
+  - url: "https://github.com/NASA-IMPACT/veda-docs/blob/main/example-notebooks/nceo-biomass-statistics.ipynb"
+    label: View example notebook
+    title: 'Static view in VEDA documentation'
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FNASA-IMPACT%2Fveda-docs&branch=main&urlpath=lab%2Ftree%2Fveda-docs%2Fexample-notebooks%2Fnceo-biomass-statistics.ipynb"
+    label: Run example notebook
+    title: 'Interactive session in VEDA 2i2c JupyterHub (requires account)'
 media:
   src: ::file ./nceo-africa--dataset-cover.jpg
   alt: Green trees seen from above


### PR DESCRIPTION
## What am I changing and why

Added the nbgitpuller links for two datasets examples we have in `/veda-docs`:

https://nasa-impact.github.io/veda-docs/example-notebooks/ocean-npp-timeseries-analysis.html
https://nasa-impact.github.io/veda-docs/example-notebooks/nceo-biomass-statistics.html


## How to test

* review yaml and make sure I didn't butcher it 😉 
* Open nbgitpuller links and run through the notebooks to make sure all cells works

## ⚠️ Checks

- [ ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.