### PR TITLE
Adjust datetime for snowpack discovery

### DIFF
--- a/discoveries/projected-changes-WUS-snow.discoveries.mdx
+++ b/discoveries/projected-changes-WUS-snow.discoveries.mdx
@@ -36,7 +36,7 @@ thematics:
     <Map
       datasetId='CMIP-winter-median-ta'
       layerId='CMIP245-winter-median-ta'
-      dateTime='2085-02-14'
+      dateTime='2085-01-01'
       zoom={4.0}
       center={[-113.,40.]}
       compareDateTime='2099-01-01'
@@ -55,7 +55,7 @@ thematics:
     <Map
       datasetId='CMIP-winter-median-pr'
       layerId='CMIP245-winter-median-pr'
-      dateTime='2085-02-14'
+      dateTime='2085-01-01'
       zoom={4.0}
       center={[-113.,40.]}
       compareDateTime='2099-01-01'


### PR DESCRIPTION
## What am I changing and why

This discovery is failing to identify valid datasets for the provided date. We've documented this issue in [#170](https://github.com/NASA-IMPACT/veda-backend/issues/170) but have not been able to implement and deploy a fix. This PR should allow the discovery to display the correct data in the meantime.