### PR TITLE
Content: Slowdown & Recovery Proxy Maps

### DIFF
--- a/datasets/recovery-proxy-maps-covid-19.data.mdx
+++ b/datasets/recovery-proxy-maps-covid-19.data.mdx
@@ -11,23 +11,13 @@ layers:
     zoomExtent:
       - 0
       - 20
-    # sourceParams:
-    #   colormap_name: rdylgn_r
-    #   rescale:
-    #     - 1
-    #     - 4
-    #   nodata: nan
-    # legend:
-    #   type: categorical
-    #   stops:
-    #     - color: "#94c772"
-    #       label: "Unburned"
-    #     - color: "#faf88e"
-    #       label: "Low"
-    #     - color: "#ea915e"
-    #       label: "Moderate"
-    #     - color: "#971d2b"
-    #       label: "High"
+    legend:
+      type: gradient
+      min: "Less Recovery"
+      max: "Greater Recovery"
+      stops:
+        - "#f7f702"
+        - "#f7b602"
 
 ---
 

--- a/datasets/recovery-proxy-maps-covid-19.data.mdx
+++ b/datasets/recovery-proxy-maps-covid-19.data.mdx
@@ -1,0 +1,41 @@
+---
+id: recovery-proxy-maps-covid-19
+name: "Covid 19 Recovery Proxy Map"
+description: "Recovery Proxy Maps show areas with the greatest increase in car activity shaded in orange. Darker orange indicates areas of greater change."
+layers:
+  - id: recovery-proxy-maps-covid-19
+    stacCol: recovery-proxy-maps-covid-19
+    name: Covid 19 Recovery Proxy Map
+    type: raster
+    description: "Recovery Proxy Maps show areas with the greatest increase in car activity shaded in orange. Darker orange indicates areas of greater change."
+    zoomExtent:
+      - 0
+      - 20
+    # sourceParams:
+    #   colormap_name: rdylgn_r
+    #   rescale:
+    #     - 1
+    #     - 4
+    #   nodata: nan
+    # legend:
+    #   type: categorical
+    #   stops:
+    #     - color: "#94c772"
+    #       label: "Unburned"
+    #     - color: "#faf88e"
+    #       label: "Low"
+    #     - color: "#ea915e"
+    #       label: "Moderate"
+    #     - color: "#971d2b"
+    #       label: "High"
+
+---
+
+<Block>
+  <Prose>
+    ## About
+    
+    Recovery Proxy Maps show areas with the greatest increase in car activity shaded in orange. Darker orange indicates areas of greater change.
+    
+  </Prose>
+</Block>

--- a/datasets/slowdown-proxy-covid-19-changing-landscapes.data.mdx
+++ b/datasets/slowdown-proxy-covid-19-changing-landscapes.data.mdx
@@ -11,23 +11,13 @@ layers:
     zoomExtent:
       - 0
       - 20
-    # sourceParams:
-    #   colormap_name: rdylgn_r
-    #   rescale:
-    #     - 1
-    #     - 4
-    #   nodata: nan
-    # legend:
-    #   type: categorical
-    #   stops:
-    #     - color: "#94c772"
-    #       label: "Unburned"
-    #     - color: "#faf88e"
-    #       label: "Low"
-    #     - color: "#ea915e"
-    #       label: "Moderate"
-    #     - color: "#971d2b"
-    #       label: "High"
+    legend:
+      type: gradient
+      min: "Less Slowdown"
+      max: "Greater Slowdown"
+      stops:
+        - "#0223c9"
+        - "#011161"
 
 ---
 

--- a/datasets/slowdown-proxy-covid-19-changing-landscapes.data.mdx
+++ b/datasets/slowdown-proxy-covid-19-changing-landscapes.data.mdx
@@ -1,0 +1,41 @@
+---
+id: slowdown-proxy-covid-19-changing-landscapes
+name: "Covid 19 Slowdown Proxy Map"
+description: "Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change."
+layers:
+  - id: recovery-proxy-maps-covid-19
+    stacCol: recovery-proxy-maps-covid-19
+    name: Covid 19 Recovery Proxy Map
+    type: raster
+    description: "Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change."
+    zoomExtent:
+      - 0
+      - 20
+    # sourceParams:
+    #   colormap_name: rdylgn_r
+    #   rescale:
+    #     - 1
+    #     - 4
+    #   nodata: nan
+    # legend:
+    #   type: categorical
+    #   stops:
+    #     - color: "#94c772"
+    #       label: "Unburned"
+    #     - color: "#faf88e"
+    #       label: "Low"
+    #     - color: "#ea915e"
+    #       label: "Moderate"
+    #     - color: "#971d2b"
+    #       label: "High"
+
+---
+
+<Block>
+  <Prose>
+    ## About
+    
+    Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change.
+    
+  </Prose>
+</Block>

--- a/datasets/slowdown-proxy-covid-19-changing-landscapes.data.mdx
+++ b/datasets/slowdown-proxy-covid-19-changing-landscapes.data.mdx
@@ -3,9 +3,9 @@ id: slowdown-proxy-covid-19-changing-landscapes
 name: "Covid 19 Slowdown Proxy Map"
 description: "Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change."
 layers:
-  - id: recovery-proxy-maps-covid-19
-    stacCol: recovery-proxy-maps-covid-19
-    name: Covid 19 Recovery Proxy Map
+  - id: slowdown-proxy-covid-19-changing-landscapes
+    stacCol: slowdown-proxy-covid-19-changing-landscapes
+    name: Covid 19 Slowdown Proxy Map
     type: raster
     description: "Slowdown Proxy Maps show areas with the greatest reduction in car activity shaded in blue. Darker blues indicate areas of greater change."
     zoomExtent:


### PR DESCRIPTION
## Adding content

Content for Covid 19 slowdown and recovery proxy datasets.

---

## Content checklist

Check the [Content Documentation](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/CONTENT.md) for more details.

### Any content
- [ ] Cover image with proper attribution (when relevant) is present.
- [ ] Cover images do not contain any text (they're used as a background and text may not be readable).
- [ ] All images are not too big/heavy. As a general rule of thumb, they should not weigh more than 500KB, or be larger than 2000px. See the [media guide](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/frontmatter/media.md#media) for more info.
- [x] Content was added using the available [MDX Blocks](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/MDX_BLOCKS.md).

### Datasets
- [x] [Layer description](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/frontmatter/layer.md#properties) is defined.
- [x] [Layer legend](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/frontmatter/layer.md#legend) is setup.
- [x] The Dataset is showing up on the map correctly

### Discoveries
- [ ] [Publication date](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/CONTENT.md#discoveries) value is set
