### PR TITLE
Fix links to veda-docs notebooks

### DIFF
--- a/datasets/hls-events.ej.data.mdx
+++ b/datasets/hls-events.ej.data.mdx
@@ -3,10 +3,10 @@ id: hls_events
 name: 'Harmonized Landsat Sentinel-2 (Selected Events)'
 description: '30-meter resolution harmonized Landsat 8/9 and Sentinel-2A/B data products'
 usage:
-  - url: "https://nasa-impact.github.io/veda-documentation/hls-visualization.html"
+  - url: "https://nasa-impact.github.io/veda-docs/notebooks/quickstarts/hls-visualization.html"
     label: View example notebook
     title: 'Multi-Band Visualization Preview for Harmonized Landsat Sentinel-2 (HLS)'
-  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-documentation&urlpath=lab/tree/veda-documentation/hls-visualization.ipynb&branch=main"
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&urlpath=lab/tree/veda-docs/notebooks/quickstarts/hls-visualization.ipynb&branch=main"
     label: Run example notebook
     title: 'Multi-Band Visualization Preview for Harmonized Landsat Sentinel-2 (HLS)'
 media:
@@ -66,7 +66,7 @@ The data currently in this dashboard represents a subset of the available data. 
 <Block>
 <Prose>
 ## Scientific research
-The production of atmospherically corrected HLS products is a collaborative effort between NASA, the U.S. Geological Survey (USGS), and the European Space Agency (ESA). Bandpass adjustments applied to Sentinel-2 data spectral bands match surface reflectance values in corresponding spectral bands in Landsat 8 and 9. This adjustment allows for 30m observation of the land surface every 2-4 days. HLSL30 and HLSS30 products are typically used for land use land cover applications including land use change, land use classification, fire monitoring, agricultural monitoring, and flooding, among others. 
+The production of atmospherically corrected HLS products is a collaborative effort between NASA, the U.S. Geological Survey (USGS), and the European Space Agency (ESA). Bandpass adjustments applied to Sentinel-2 data spectral bands match surface reflectance values in corresponding spectral bands in Landsat 8 and 9. This adjustment allows for 30m observation of the land surface every 2-4 days. HLSL30 and HLSS30 products are typically used for land use land cover applications including land use change, land use classification, fire monitoring, agricultural monitoring, and flooding, among others.
 </Prose>
 </Block>
 

--- a/datasets/mo_npp_vgpm.data.mdx
+++ b/datasets/mo_npp_vgpm.data.mdx
@@ -3,10 +3,10 @@ id: npp
 name: "Ocean Net Primary Production"
 description: "Ocean Net Primary Production (NPP)"
 usage:
-  - url: 'https://github.com/NASA-IMPACT/veda-docs/blob/main/example-notebooks/ocean-npp-timeseries-analysis.ipynb'
+  - url: 'https://github.com/NASA-IMPACT/veda-docs/blob/main/notebooks/datasets/ocean-npp-timeseries-analysis.ipynb'
     label: View example notebook
     title: 'Static view in VEDA documentation'
-  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FNASA-IMPACT%2Fveda-docs&branch=main&urlpath=lab%2Ftree%2Fveda-docs%2Fexample-notebooks%2Focean-npp-timeseries-analysis.ipynb"
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&branch=main&urlpath=lab/tree/veda-docs/notebooks/datasets/ocean-npp-timeseries-analysis.ipynb"
     label: Run example notebook
     title: 'Interactive session in VEDA 2i2c JupyterHub (requires account)'
 media:

--- a/datasets/nceo_africa_2017.data.mdx
+++ b/datasets/nceo_africa_2017.data.mdx
@@ -3,10 +3,10 @@ id: nceo_africa_2017
 name: "National Centre for Earth Observation (NCEO) Biomass"
 description: The NCEO Africa Aboveground Woody Biomass (AGB) map for the year 2017 at 100 m spatial resolution
 usage:
-  - url: "https://github.com/NASA-IMPACT/veda-docs/blob/main/example-notebooks/nceo-biomass-statistics.ipynb"
+  - url: "https://github.com/NASA-IMPACT/veda-docs/blob/main/notebooks/datasets/nceo-biomass-statistics.ipynb"
     label: View example notebook
     title: 'Static view in VEDA documentation'
-  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FNASA-IMPACT%2Fveda-docs&branch=main&urlpath=lab%2Ftree%2Fveda-docs%2Fexample-notebooks%2Fnceo-biomass-statistics.ipynb"
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&branch=main&urlpath=lab/tree/veda-docs/notebooks/datasets/nceo-biomass-statistics.ipynb"
     label: Run example notebook
     title: 'Interactive session in VEDA 2i2c JupyterHub (requires account)'
 media:
@@ -22,7 +22,7 @@ layers:
     stacCol: nceo_africa_2017
     name: NCEO Africa Aboveground Woody Biomass
     type: raster
-    description: The NCEO Africa Aboveground Woody Biomass (AGB) map for the year 2017 at 100 m spatial resolution 
+    description: The NCEO Africa Aboveground Woody Biomass (AGB) map for the year 2017 at 100 m spatial resolution
     zoomExtent:
       - 0
       - 16

--- a/datasets/no2.data.mdx
+++ b/datasets/no2.data.mdx
@@ -7,7 +7,7 @@ usage:
   - url: 'https://github.com/NASA-IMPACT/veda-docs/blob/main/notebooks/quickstarts/no2-map-plot.ipynb'
     label: View example notebook
     title: 'Static view in VEDA documentation'
-  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&branch=main&urlpath=lab/tree/veda-docs/notebooks/quickstarts/no2-map-plot.ipynbn"
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&branch=main&urlpath=lab/tree/veda-docs/notebooks/quickstarts/no2-map-plot.ipynb"
     label: Run example notebook
     title: 'Interactive session in VEDA 2i2c JupyterHub (requires account)'
 media:

--- a/datasets/no2.data.mdx
+++ b/datasets/no2.data.mdx
@@ -7,7 +7,7 @@ usage:
   - url: 'https://github.com/NASA-IMPACT/veda-docs/blob/main/notebooks/quickstarts/no2-map-plot.ipynb'
     label: View example notebook
     title: 'Static view in VEDA documentation'
-  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FNASA-IMPACT%2Fveda-docs&urlpath=lab%2Ftree%2Fveda-docs%2Fnotebooks%2Fquickstarts%2Fno2-map-plot.ipynb&branch=main"
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&branch=main&urlpath=lab/tree/veda-docs/notebooks/quickstarts/no2-map-plot.ipynbn"
     label: Run example notebook
     title: 'Interactive session in VEDA 2i2c JupyterHub (requires account)'
 media:
@@ -151,12 +151,12 @@ Scientists will use these data to investigate how travel bans and lockdown order
   src={new URL('./no2-south-america.jpg', import.meta.url).href}
   alt='NO2 levels over South America from the Ozone Monitoring Instrument'
   />
-  <Caption 
-    attrAuthor='NASA' 
+  <Caption
+    attrAuthor='NASA'
     attrUrl='https://nasa.gov/'
   >
-    NO2 levels over South America from the Ozone Monitoring Instrument. The dark green areas in the northwest indicate areas of no data, most likely associated with cloud cover or snow. 
-  </Caption> 
+    NO2 levels over South America from the Ozone Monitoring Instrument. The dark green areas in the northwest indicate areas of no data, most likely associated with cloud cover or snow.
+  </Caption>
 </Figure>
 <Prose>
 ## Interpreting the data

--- a/datasets/svi_overall.ej.data.mdx
+++ b/datasets/svi_overall.ej.data.mdx
@@ -3,10 +3,10 @@ id: svi-overall
 name: 'Overall Social Vulnerability'
 description: "Overall score for the Centers for Disease Control and Prevention (CDC) Social Vulnerability Index (SVI) gridded at a spatial resolution of 1 km"
 usage:
-  - url: 'https://nasa-impact.github.io/veda-documentation/open-and-plot.html'
+  - url: 'https://nasa-impact.github.io/veda-docs/notebooks/quickstarts/open-and-plot.html'
     label: View example notebook
     title: 'Open and Visualize SVI data'
-  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-documentation&urlpath=lab/tree/veda-documentation/svi-overall.ipynb&branch=main"
+  - url: "https://nasa-veda.2i2c.cloud/hub/user-redirect/git-pull?repo=https://github.com/NASA-IMPACT/veda-docs&branch=main&urlpath=lab/tree/veda-docs/notebooks/quickstarts/open-and-plot.ipynb"
     label: Run example notebook
     title: 'Open and Visualize SVI data'
 media:


### PR DESCRIPTION
## What am I changing and why

I noticed that there are some links to veda-docs notebooks that have moved. This PR updates those links.

## ⚠️ Checks

- [x] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.