### PR TITLE
Update workflow to use OIDC for deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,12 +10,11 @@ on:
   push:
     branches:
     - 'main'
-    - test-oidc
 
 env:
   NODE: 16
-  DOMAIN_PROD: /dashboard
-  DEPLOY_BUCKET_PROD: covid-eo-uat
+  DOMAIN_PROD: https://www.earthdata.nasa.gov/dashboard
+  DEPLOY_BUCKET_PROD: climatedashboard
   DEPLOY_BUCKET_PROD_REGION: us-east-1
 
 jobs:
@@ -107,7 +106,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: "veda-dashboard-prod-deployment"
-          aws-region: "us-east-1"
+          aws-region: ${{ env.DEPLOY_BUCKET_PROD_REGION }}
 
       - name: Deploy to S3 Production
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,15 +2,20 @@
 
 name: Deploy Production - MCP (S3)
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   push:
     branches:
     - 'main'
+    - test-oidc
 
 env:
   NODE: 16
-  DOMAIN_PROD: https://www.earthdata.nasa.gov/dashboard
-  DEPLOY_BUCKET_PROD: climatedashboard
+  DOMAIN_PROD: /dashboard
+  DEPLOY_BUCKET_PROD: covid-eo-uat
   DEPLOY_BUCKET_PROD_REGION: us-east-1
 
 jobs:
@@ -97,28 +102,18 @@ jobs:
           mv dist deploy/dashboard
           cp deploy/dashboard/index.html deploy/index.html
 
-      - name: Deploy to S3 Production
-        uses: jakejarvis/s3-sync-action@master
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          # acl is not permitted with current credentials
-          # args: --acl public-read --follow-symlinks --delete
-          args: --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: ${{ env.DEPLOY_BUCKET_PROD }}
-          AWS_REGION: ${{ env.DEPLOY_BUCKET_PROD_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # When serving from a subpath:
-          # SOURCE_DIR: ./deploy
-          # Otherwise use the build directory directly:
-          # SOURCE_DIR: ./dist
-          SOURCE_DIR: ./deploy
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "veda-dashboard-prod-deployment"
+          aws-region: "us-east-1"
+
+      - name: Deploy to S3 Production
+        run: |
+          aws s3 sync ./deploy s3://${{ env.DEPLOY_BUCKET_PROD }}  --delete
 
       - name: Invalidate CloudFront cache
-        uses: chetan/invalidate-cloudfront-action@v2
-        env:
-          DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_PROD }}
-          PATHS: "/*"
-          AWS_REGION: ${{ env.DEPLOY_BUCKET_PROD_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        uses: oneyedev/aws-cloudfront-invalidation@v1
+        with:
+          distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_PROD }}


### PR DESCRIPTION
## What am I changing and why

- Update workflow to use OIDC for deployment
- Added a `DEPLOYMENT_ROLE_ARN` repository secret which is the IAM role that Github workflow assumes to deploy

## How to test
I tested it by adding `test-oidc` as one of the trigger branches, and updating the following values:
```
DOMAIN_PROD: /dashboard
DEPLOY_BUCKET_PROD: covid-eo-uat (confirmed that this was not being used anywhere else first)
```
This triggered the deployment.
Checked that it worked by grabbing the static website endpoint from the `covid-eo-uat` and appending `/dashboard` at the end. The VEDA dashboard looked as expected.
Also checked the cache invalidation in the cloudfront distribution, it worked as expected.

## ⚠️ Checks

- [ ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.