### PR TITLE
Use production titiler-xarray endoint

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
 
 # Endpoint for the STAC server. No trailing slash.
 API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
-API_XARRAY_ENDPOINT='https://dev-titiler-xarray.delta-backend.com/tilejson.json'
+API_XARRAY_ENDPOINT='https://prod-titiler-xarray.delta-backend.com/tilejson.json'
 
 MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 


### PR DESCRIPTION
There are now 2 deployments of titiler-xarray: one production endpoint and one dev. Dev will be reserved for new feature development and testing, so we should use the production endpoint in VEDA dashboard services. 