### PR TITLE
Update source params for HLS SWIR

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ APP_DESCRIPTION=Visualization, Exploration, and Data Analysis (VEDA)
 APP_CONTACT_EMAIL=email@example.org
 
 # Endpoint for the Tiler server. No trailing slash.
-API_RASTER_ENDPOINT='https://test-raster.delta-backend.com'
+API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
 
 # Endpoint for the STAC server. No trailing slash.
 API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'

--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ APP_DESCRIPTION=Visualization, Exploration, and Data Analysis (VEDA)
 APP_CONTACT_EMAIL=email@example.org
 
 # Endpoint for the Tiler server. No trailing slash.
-API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
+API_RASTER_ENDPOINT='https://test-raster.delta-backend.com'
 
 # Endpoint for the STAC server. No trailing slash.
 API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'

--- a/datasets/hls-events.ej.data.mdx
+++ b/datasets/hls-events.ej.data.mdx
@@ -29,7 +29,7 @@ layers:
       - 4
       - 20
     sourceParams:
-      post_process: swir
+      algorithm: swir
       assets:
         - B07
         - B05
@@ -50,7 +50,7 @@ layers:
       - 4
       - 20
     sourceParams:
-      post_process: swir
+      algorithm: swir
       assets:
         - B12
         - B8A


### PR DESCRIPTION
## What am I changing and why
Updated sourceParams in HLS dataset to use `algorithm` in place of `post_process`. See corresponding raster-api change in [veda-backend PR 239](https://github.com/NASA-IMPACT/veda-backend/pull/239) .
> **Note!**
> This PR should not be merged until after the backend api is updated 2023-11-07 

## How to test
I confirmed that the change yields the correct formatting from a test version of the backend stack: https://test-raster.delta-backend.com/mosaic/1b7cfa7ab6b9f8890a7f52d824b4e17c/tiles/WebMercatorQuad/8/81/114?assets=B07&assets=B05&assets=B04&algorithm=swir

## ⚠️ Checks

- [ ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.