### PR TITLE
replace broken links to /datasets with /data-catalog

### DIFF
--- a/datasets/global-reanalysis-da.data.mdx
+++ b/datasets/global-reanalysis-da.data.mdx
@@ -368,7 +368,7 @@ The output variables available on VEDA include evapotranspiration (ET), gross pr
 <Block>
 <Prose>
 ## Explore the Data
-The global reanalysis is a large dataset with nearly two decades of daily output. Here we show a comparison of two dates for a single variable. We encourage users to <Link to='/datasets/global-reanalysis-da/explore'>Explore the Data></Link> to look at different dates and to compare variables.
+The global reanalysis is a large dataset with nearly two decades of daily output. Here we show a comparison of two dates for a single variable. We encourage users to <Link to='/data-catalog/global-reanalysis-da/explore'>Explore the Data></Link> to look at different dates and to compare variables.
 
 An example of how trends calculated from the global reanalysis model output can be used to understand changes in TWS, GPP, and ET, can be seen in the <Link to='/stories/tws-trends'>corresponding data story</Link>.
 </Prose>


### PR DESCRIPTION
The datasets were replaced by the data-catalog in `datasets/global-reanalysis-da.data.mdx.`  Problem #385.