### PR TITLE
Fixing the cache max age during the deployment to an S3

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Deploy to S3 Production
         run: |
-          aws s3 sync ./deploy s3://${{ env.DEPLOY_BUCKET_PROD }} --cache-control max-age=604800 --delete
+          aws s3 sync ./deploy s3://${{ env.DEPLOY_BUCKET_PROD }} --cache-control max-age=30,must-revalidate,s-maxage=604800 --delete
 
       - name: Invalidate CloudFront cache
         uses: oneyedev/aws-cloudfront-invalidation@v1


### PR DESCRIPTION
The PR contains setting the max-age=30, must-revalidate, s-maxage=60 parameters to force the reloading of asset files when necessary.
This line ensures that the resource is cached for up to 30 seconds for individual clients, but shared caches must revalidate it after 60 seconds to ensure it remains fresh. The must-revalidate directive enforces revalidation once the resource becomes stale, regardless of whether it's in an individual or shared cache.


