### PR TITLE
Add tile endpoint for CMIP6

### DIFF
--- a/datasets/cmip6-tas.data.mdx
+++ b/datasets/cmip6-tas.data.mdx
@@ -18,6 +18,7 @@ layers:
     stacCol: combined_CMIP6_daily_GISS-E2-1-G_tas_kerchunk_DEMO
     name: CMIP6 Daily GISS-E2-1-G Near-Surface Air Temperature (demo subset)
     type: zarr
+    tileApiEndpoint: 'https://prod-titiler-xarray.delta-backend.com/tilejson.json'
     description: "Historical (1950-2014) daily-mean near-surface (usually, 2 meter) air temperature in Kelvin."
     zoomExtent:
       - 0


### PR DESCRIPTION
CMIP6 is broken in the current dashboard because, I think, changes were made to use the `tileApiEndpoint` for zarr dataset layers.

[`tileApiEndpoint`](https://github.com/NASA-IMPACT/veda-ui/blob/main/app/scripts/components/common/mapbox/layers/zarr-timeseries.tsx#L16) is marked as an optional parameter but I wonder if it should actually be required.