### PR TITLE
temporarily use staging apis for nlcd data

### DIFF
--- a/datasets/nlcd-urbanization.data.mdx
+++ b/datasets/nlcd-urbanization.data.mdx
@@ -177,7 +177,7 @@ layers:
   
   ## Data Stories Using This Dataset
   
-  **<Link to={"/stories/houston-aod"}Aerosols and Their Impacts on Houston, TX]</Link>**
+  **<Link to={"/stories/houston-aod"}Aerosols and Their Impacts on Houston, TX</Link>**
 
   </Prose>
 </Block>

--- a/datasets/nlcd-urbanization.data.mdx
+++ b/datasets/nlcd-urbanization.data.mdx
@@ -36,7 +36,6 @@ layers:
       colormap_name: reds
       nodata: 0
       assets: landcover
-      resampling: cubic_spline
       rescale:
         - 0
         - 1

--- a/datasets/nlcd-urbanization.data.mdx
+++ b/datasets/nlcd-urbanization.data.mdx
@@ -35,6 +35,8 @@ layers:
     sourceParams:
       colormap_name: reds
       nodata: 0
+      assets: landcover
+      resampling: cubic_spline
       rescale:
         - 0
         - 1

--- a/datasets/nlcd-urbanization.data.mdx
+++ b/datasets/nlcd-urbanization.data.mdx
@@ -22,6 +22,8 @@ infoDescription: |
     The National Land Cover Database (NLCD) stands as a paramount dataset offering an in-depth overview of the land cover characteristics in the United States. Spearheaded by the Earth Resources Observation and Science (EROS) Center, this database is renewed every two to three years to provide updated and accurate data for the nation.
 layers:
   - id: nlcd-new-urbanization
+    stacApiEndpoint: https://staging.openveda.cloud/api/stac
+    tileApiEndpoint: https://staging.openveda.cloud/api/raster
     stacCol: nlcd-new-urbanization
     name: Urbanization
     type: raster

--- a/datasets/nlcd-urbanization.data.mdx
+++ b/datasets/nlcd-urbanization.data.mdx
@@ -177,7 +177,7 @@ layers:
   
   ## Data Stories Using This Dataset
   
-  **<Link to={"/stories/houston-aod"}Aerosols and Their Impacts on Houston, TX</Link>**
+  **<Link to={"/stories/houston-aod"}>Aerosols and Their Impacts on Houston, TX</Link>**
 
   </Prose>
 </Block>

--- a/datasets/nlcd.data.mdx
+++ b/datasets/nlcd.data.mdx
@@ -21,6 +21,8 @@ taxonomy:
       - MRLC
 layers:
   - id: nlcd-annual-conus
+    stacApiEndpoint: https://staging.openveda.cloud/api/stac
+    tileApiEndpoint: https://staging.openveda.cloud/api/raster
     stacCol: nlcd-annual-conus
     name: NLCD Land Use - Land Cover Classification
     type: raster
@@ -32,6 +34,9 @@ layers:
     sourceParams:
         assets: landcover
         bidx: [1]
+        nodata: 0
+        resampling: nearest
+        colormap_name: nlcd
     legend:
       type: categorical
       min: "0"


### PR DESCRIPTION
This is a quick diff to explore using staging urls for a dataset that needs a colormap not yet available in production