### PR TITLE
Bump package json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-config",
   "description": "Configuration for Veda",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "source": "./.veda/ui/app/index.html",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
v0.16.0 seems to have been released, but no release tag was created. Bumping to v0.17.0.

## Why are you creating this Pull Request?

- [Adding Datasets or Stories](?title=Content%3A%20%3Cname%3E&expand=1&template=content.md)
- [Version Release](?title=Deploy%20vX.X.X&expand=1&template=version_release.md)
- [Other](?expand=1&template=default.md)