### PR TITLE
Add back Soil Texture Dataset and black belt story

### DIFF
--- a/datasets/soil-texture.data.mdx
+++ b/datasets/soil-texture.data.mdx
@@ -1,0 +1,469 @@
+---
+id: soil-texture
+name: 'ISRIC World Soil Texture Classifications'
+description: "250 meter resolution global soil texture dataset from ISRIC, produced in 2017. Available at seven soil layer depths."
+media:
+  src: ::file ./soil-texture-background.jpeg
+  alt: Examples of two different soil types
+  author:
+    name: Soil Sensor
+    url: https://soilsensor.com/articles/soil-textures/
+taxonomy:
+  - name: Topics
+    values:
+      - Agriculture
+      - Land Cover
+  - name: Source
+    values:
+      - ISRIC
+layers:
+  - id: soil-texture-0cm
+    stacCol: soil-texture-0cm
+    name: Soil Texture at the Surface (0 cm Depth)
+    type: raster
+    description: 'ISRIC Soil Texture Classification at 0 cm'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+        colormap: '{"1":"#F89E61", "2":"#BA8560", "3": "#D8D2B4", "4": "#AE734C", "5": "#9E8478", "6": "#C6A365",
+                    "7":"#B4A67D", "8":"#E1D4C4", "9": "#BEB56D", "10": "#777C7A", "11": "#A89B6F", "12": "#E9E2AF"}'
+        nodata: 255
+
+    legend:
+        type: categorical
+        stops:
+            - color: "#F89E61"
+              label: "Clay"
+            - color: "#BA8560"
+              label: "Silty Clay"
+            - color: "#D8D2B4"
+              label: "Sandy Clay"
+            - color: "#AE734C"
+              label: "Clay Loam"
+            - color: "#9E8478"
+              label: "Silty Clay Loam"
+            - color: "#C6A365"
+              label: "Sandy Clay Loam"
+            - color: "#B4A67D"
+              label: "Loam"
+            - color: "#E1D4C4"
+              label: "Silty Loam"
+            - color: "#BEB56D"
+              label: "Sandy Loam"
+            - color: "#777C7A"
+              label: "Silt"
+            - color: "#A89B6F"
+              label: "Loamy Sand"
+            - color: "#E9E2AF"
+              label: "Sand"
+    info:
+      source: ISRIC
+      spatialExtent: Global
+      temporalResolution: Annual 
+      unit: N/A 
+
+  - id: soil-texture-5cm
+    stacCol: soil-texture-5cm
+    name: Soil Texture at 5 cm Depth
+    type: raster
+    description: 'ISRIC Soil Texture Classification at 5 cm'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+        colormap: '{"1":"#F89E61", "2":"#BA8560", "3": "#D8D2B4", "4": "#AE734C", "5": "#9E8478", "6": "#C6A365",
+                    "7":"#B4A67D", "8":"#E1D4C4", "9": "#BEB56D", "10": "#777C7A", "11": "#A89B6F", "12": "#E9E2AF"}'
+        nodata: 255
+  
+    legend:
+        type: categorical
+        stops:
+            - color: "#F89E61"
+              label: "Clay"
+            - color: "#BA8560"
+              label: "Silty Clay"
+            - color: "#D8D2B4"
+              label: "Sandy Clay"
+            - color: "#AE734C"
+              label: "Clay Loam"
+            - color: "#9E8478"
+              label: "Silty Clay Loam"
+            - color: "#C6A365"
+              label: "Sandy Clay Loam"
+            - color: "#B4A67D"
+              label: "Loam"
+            - color: "#E1D4C4"
+              label: "Silty Loam"
+            - color: "#BEB56D"
+              label: "Sandy Loam"
+            - color: "#777C7A"
+              label: "Silt"
+            - color: "#A89B6F"
+              label: "Loamy Sand"
+            - color: "#E9E2AF"
+              label: "Sand"
+    info:
+      source: ISRIC
+      spatialExtent: Global
+      temporalResolution: Annual 
+      unit: N/A 
+
+  - id: soil-texture-15cm
+    stacCol: soil-texture-15cm
+    name: Soil Texture at 15 cm Depth
+    type: raster
+    description: 'ISRIC Soil Texture Classification at 15 cm'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+        colormap: '{"1":"#F89E61", "2":"#BA8560", "3": "#D8D2B4", "4": "#AE734C", "5": "#9E8478", "6": "#C6A365",
+                    "7":"#B4A67D", "8":"#E1D4C4", "9": "#BEB56D", "10": "#777C7A", "11": "#A89B6F", "12": "#E9E2AF"}'
+        nodata: 255
+ 
+    legend:
+        type: categorical
+        stops:
+            - color: "#F89E61"
+              label: "Clay"
+            - color: "#BA8560"
+              label: "Silty Clay"
+            - color: "#D8D2B4"
+              label: "Sandy Clay"
+            - color: "#AE734C"
+              label: "Clay Loam"
+            - color: "#9E8478"
+              label: "Silty Clay Loam"
+            - color: "#C6A365"
+              label: "Sandy Clay Loam"
+            - color: "#B4A67D"
+              label: "Loam"
+            - color: "#E1D4C4"
+              label: "Silty Loam"
+            - color: "#BEB56D"
+              label: "Sandy Loam"
+            - color: "#777C7A"
+              label: "Silt"
+            - color: "#A89B6F"
+              label: "Loamy Sand"
+            - color: "#E9E2AF"
+              label: "Sand"
+    info:
+      source: ISRIC
+      spatialExtent: Global
+      temporalResolution: Annual 
+      unit: N/A 
+
+  - id: soil-texture-30cm
+    stacCol: soil-texture-30cm
+    name: Soil Texture at 30 cm Depth
+    type: raster
+    description: 'ISRIC Soil Texture Classification at 30 cm'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+        colormap: '{"1":"#F89E61", "2":"#BA8560", "3": "#D8D2B4", "4": "#AE734C", "5": "#9E8478", "6": "#C6A365",
+                    "7":"#B4A67D", "8":"#E1D4C4", "9": "#BEB56D", "10": "#777C7A", "11": "#A89B6F", "12": "#E9E2AF"}'
+        nodata: 255
+
+    legend:
+        type: categorical
+        stops:
+            - color: "#F89E61"
+              label: "Clay"
+            - color: "#BA8560"
+              label: "Silty Clay"
+            - color: "#D8D2B4"
+              label: "Sandy Clay"
+            - color: "#AE734C"
+              label: "Clay Loam"
+            - color: "#9E8478"
+              label: "Silty Clay Loam"
+            - color: "#C6A365"
+              label: "Sandy Clay Loam"
+            - color: "#B4A67D"
+              label: "Loam"
+            - color: "#E1D4C4"
+              label: "Silty Loam"
+            - color: "#BEB56D"
+              label: "Sandy Loam"
+            - color: "#777C7A"
+              label: "Silt"
+            - color: "#A89B6F"
+              label: "Loamy Sand"
+            - color: "#E9E2AF"
+              label: "Sand"
+    info:
+      source: ISRIC
+      spatialExtent: Global
+      temporalResolution: Annual 
+      unit: N/A 
+
+  - id: soil-texture-60cm
+    stacCol: soil-texture-60cm
+    name: Soil Texture at 60 cm Depth
+    type: raster
+    description: 'ISRIC Soil Texture Classification at 60 cm'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+        colormap: '{"1":"#F89E61", "2":"#BA8560", "3": "#D8D2B4", "4": "#AE734C", "5": "#9E8478", "6": "#C6A365",
+                    "7":"#B4A67D", "8":"#E1D4C4", "9": "#BEB56D", "10": "#777C7A", "11": "#A89B6F", "12": "#E9E2AF"}'
+        nodata: 255
+  
+    legend:
+        type: categorical
+        stops:
+            - color: "#F89E61"
+              label: "Clay"
+            - color: "#BA8560"
+              label: "Silty Clay"
+            - color: "#D8D2B4"
+              label: "Sandy Clay"
+            - color: "#AE734C"
+              label: "Clay Loam"
+            - color: "#9E8478"
+              label: "Silty Clay Loam"
+            - color: "#C6A365"
+              label: "Sandy Clay Loam"
+            - color: "#B4A67D"
+              label: "Loam"
+            - color: "#E1D4C4"
+              label: "Silty Loam"
+            - color: "#BEB56D"
+              label: "Sandy Loam"
+            - color: "#777C7A"
+              label: "Silt"
+            - color: "#A89B6F"
+              label: "Loamy Sand"
+            - color: "#E9E2AF"
+              label: "Sand"
+    info:
+      source: ISRIC
+      spatialExtent: Global
+      temporalResolution: Annual 
+      unit: N/A 
+
+  - id: soil-texture-100cm
+    stacCol: soil-texture-100cm
+    name: Soil Texture at 100 cm Depth
+    type: raster
+    description: 'ISRIC Soil Texture Classification at 100 cm'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+        colormap: '{"1":"#F89E61", "2":"#BA8560", "3": "#D8D2B4", "4": "#AE734C", "5": "#9E8478", "6": "#C6A365",
+                    "7":"#B4A67D", "8":"#E1D4C4", "9": "#BEB56D", "10": "#777C7A", "11": "#A89B6F", "12": "#E9E2AF"}'
+        nodata: 255
+
+    legend:
+        type: categorical
+        stops:
+            - color: "#F89E61"
+              label: "Clay"
+            - color: "#BA8560"
+              label: "Silty Clay"
+            - color: "#D8D2B4"
+              label: "Sandy Clay"
+            - color: "#AE734C"
+              label: "Clay Loam"
+            - color: "#9E8478"
+              label: "Silty Clay Loam"
+            - color: "#C6A365"
+              label: "Sandy Clay Loam"
+            - color: "#B4A67D"
+              label: "Loam"
+            - color: "#E1D4C4"
+              label: "Silty Loam"
+            - color: "#BEB56D"
+              label: "Sandy Loam"
+            - color: "#777C7A"
+              label: "Silt"
+            - color: "#A89B6F"
+              label: "Loamy Sand"
+            - color: "#E9E2AF"
+              label: "Sand"
+    info:
+      source: ISRIC
+      spatialExtent: Global
+      temporalResolution: Annual 
+      unit: N/A 
+
+  - id: soil-texture-200cm
+    stacCol: soil-texture-200cm
+    name: Soil Texture at 200 cm Depth
+    type: raster
+    description: 'ISRIC Soil Texture Classification at 200 cm'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+        colormap: '{"1":"#F89E61", "2":"#BA8560", "3": "#D8D2B4", "4": "#AE734C", "5": "#9E8478", "6": "#C6A365",
+                    "7":"#B4A67D", "8":"#E1D4C4", "9": "#BEB56D", "10": "#777C7A", "11": "#A89B6F", "12": "#E9E2AF"}'
+        nodata: 255
+ 
+    legend:
+        type: categorical
+        stops:
+            - color: "#F89E61"
+              label: "Clay"
+            - color: "#BA8560"
+              label: "Silty Clay"
+            - color: "#D8D2B4"
+              label: "Sandy Clay"
+            - color: "#AE734C"
+              label: "Clay Loam"
+            - color: "#9E8478"
+              label: "Silty Clay Loam"
+            - color: "#C6A365"
+              label: "Sandy Clay Loam"
+            - color: "#B4A67D"
+              label: "Loam"
+            - color: "#E1D4C4"
+              label: "Silty Loam"
+            - color: "#BEB56D"
+              label: "Sandy Loam"
+            - color: "#777C7A"
+              label: "Silt"
+            - color: "#A89B6F"
+              label: "Loamy Sand"
+            - color: "#E9E2AF"
+              label: "Sand"
+    info:
+      source: ISRIC
+      spatialExtent: Global
+      temporalResolution: Annual 
+      unit: N/A 
+
+---
+<Block>
+  <Prose>
+  ## Dataset Details
+  - **Temporal Extent:** 2017
+  - **Temporal Resolution:** N/A
+  - **Spatial Extent:** Global
+  - **Spatial Resolution:** 250 m
+  - **Data Units:** N/A
+  - **Data Type:** Research
+  - **Data Latency:** N/A
+  </Prose>
+<Figure>
+  <Map
+    datasetId='soil-texture-0cm'
+    layerId='soil-texture-0cm'
+    dateTime='2017-01-01'
+    zoom={5}
+    center={[-84,40]}
+  />
+  <Caption
+    attrAuthor='NASA'
+    attrUrl='https://nasa.gov/'
+  >
+    ISRIC surface soil texture classifications (0 cm depth) in the Ohio River Valley.
+  </Caption>
+</Figure>
+</Block>
+
+<Block>
+   <Figure>
+      <Image
+      src={new URL('./soil-texture-triangle.jpeg', import.meta.url).href}
+      alt='Soil Texture Classification Triangle.'
+    />
+    <Caption>
+    ISRIC Soil Texture Classification Triangle showing the percentage of clay, silt, and sand in each type.
+    </Caption>
+  </Figure>
+  
+   <Prose>
+    ### About
+    The ISRIC Soil Texture dataset (SoilGrids 250) provides detailed soil texture classifications, which are critical for understanding soil properties, water retention, and agricultural potential. Maintained by the International Soil Reference and Information Centre (ISRIC), this dataset has been instrumental in various environmental and agricultural studies across the globe. This classification system breaks soils down into different categories based on their percentage of sand, silt, and clay, providing an essential resource for researchers, land managers, and farmers.
+  </Prose>
+</Block>
+
+<Block>
+  <Prose>
+    ### What the ISRIC Soil Texture Dataset Offers
+    - Soil Texture Classes: This dataset classifies soils into twelve texture categories, ranging from sand, silt, and clay, to more complex combinations such as loam, clay loam, and silty clay. Each category offers a distinct combination of sand, silt, and clay content, helping users determine soil characteristics.
+    
+    - Soil Texture Triangle: A visualization tool used to depict the relationships between the percentage of sand, silt, and clay in soil. It allows users to easily locate and interpret soil types based on their texture composition.
+    
+    - Applications in Agriculture and Environmental Studies: The soil texture classification is pivotal in determining soil fertility, drainage capabilities, and erosion potential, making it crucial for land use planning, crop management, and climate studies.
+  </Prose>
+</Block>
+
+
+<Block>
+  <Prose>
+  
+  ### Access the Data
+
+  Visit the [SoilGrids](https://www.soilgrids.org) webpage to explore all of the data options that SoilGrids 250 offers.
+
+  </Prose>
+</Block>
+
+<Block>
+  <Prose>
+    
+  ### Citing this Dataset
+
+  Hengl, T., de Jesus, J.M., Heuvelink, G.B.M., Gonzalez, M.R., Kilibarda, M., Blagotić, A., ... & Kempen, B. (2017). SoilGrids250m: Global gridded soil information based on machine learning. PLoS One, 12(2), e0169748. https://doi.org/10.1371/journal.pone.0169748
+  
+  </Prose>
+</Block>
+
+<Block>
+  <Prose>
+  
+  ## Disclaimer
+
+  All data provided in VEDA has been transformed from the original format (TIFF) into Cloud Optimized GeoTIFFs ([COG](https://www.cogeo.org)). Careful quality checks are used to ensure data transformation has been performed correctly.  
+  
+  </Prose>
+</Block>
+
+<Block>
+  <Prose>
+
+  ### Key Publication
+  
+  Hengl, T., de Jesus, J.M., Heuvelink, G.B.M., Gonzalez, M.R., Kilibarda, M., Blagotić, A., ... & Kempen, B. (2017). SoilGrids250m: Global gridded soil information based on machine learning. PLoS One, 12(2), e0169748. https://doi.org/10.1371/journal.pone.0169748
+
+  </Prose>
+</Block>
+
+<Block>
+  <Prose>
+
+  ### Other Publications
+  
+  Rossiter, D. G. (2001). Methodology for soil resource inventories. Computers and Electronics in Agriculture, 35(2), 189–214.
+
+  </Prose>
+</Block>
+
+
+<Block>
+  <Prose>
+  
+  ## Data Stories Using This Dataset
+  
+  **[Climate Extremes Aggrevate Social Vulnerabilities in Alabama's Black Belt](https://www.earthdata.nasa.gov/dashboard/stories/black-belt-climate)**
+    
+  </Prose>
+</Block>
+
+<Block>
+  <Prose>
+  
+  ## License
+  
+  [Creative Commons Attribution 1.0 International](https://creativecommons.org/publicdomain/zero/1.0/legalcode) (CC BY 1.0)
+
+  </Prose>
+</Block>

--- a/stories/black-belt-climate-ej.stories.mdx
+++ b/stories/black-belt-climate-ej.stories.mdx
@@ -1,0 +1,316 @@
+---
+id: black-belt-climate
+name: Climate Extremes Aggravate Social Vulnerabilities in Alabama's Black Belt
+description: "Rising temperatures worsen social vulnerabilities for the elderly population by increasing their heat-related health risks."
+media:
+  src: ::file ./black_belt_cover.jpg
+  alt: Farmer in the fields.
+  author:
+    name: NASA
+    url: https://widerimage.reuters.com/photographer/lucy-nicholson.html
+pubDate: 2024-09-01
+taxonomy:
+  - name: Topics
+    values:
+      - Environmental Justice
+      - Disasters
+---
+
+<Block style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'center', width: '100%' }}>
+    <p style={{ marginBottom: '0.5em' }}>
+      Authors: Maheshwari Neelam <sup>[1]</sup>, Udaysankar Nair <sup>[2]</sup>, Andrew Blackford <sup>[2]</sup>, and Natalie P.Thomas <sup>[3]</sup>
+    </p>
+    <p style={{ marginBottom: '0.5em' }}>
+      <sup>[1]</sup> USRA and National Aeronautics and Space Administration (NASA)
+    </p>
+    <p style={{ marginBottom: '0.5em' }}>
+      <sup>[2]</sup> The University of Alabama in Huntsville
+    </p>
+    <p style={{ marginBottom: '0.5em' }}>
+      <sup>[3]</sup> University of Maryland and Global Modeling and Assimilation Office, NASA
+    </p>
+    <p style={{ marginBottom: '0.5em', fontWeight: 'bold' }}>
+      Mission: NASA Earth Action: A thriving world, driven by trusted, actionable Earth science
+    </p>
+    <p style={{ fontSize: '0.9em', fontStyle: 'italic' }}>
+      Disclaimer: This study demonstrates innovative and practical applications of NASA Earth science data to highlight existing environmental inequities. Please note that the results have not undergone peer review.
+    </p>
+  </Prose>
+</Block>
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', flex: 'auto', alignItems: 'center' }}>
+    <p>
+     The Alabama Black Belt, a region integral to the Southern United States, derives its name from its dark, fertile soil. This rich land, ideal for agriculture, especially cotton, owes its fertility to a unique geological history. Millions of years ago, when the Gulf of Mexico extended further inland, plankton deposits formed soft limestone called Selma Chalk. Over time, this limestone weathered, creating the calcium-rich, chalky subsoil that characterizes the Black Belt, transforming it into an agricultural powerhouse.
+    </p>
+  </Prose>
+
+  <Figure>
+    <Map
+      datasetId='soil-texture-0cm'
+      layerId='soil-texture-0cm'
+      center={[-87, 32.6]}
+      zoom={6.5}
+      dateTime='2017-01-01'
+    />
+    <Caption>
+    Surface soil textures classified from the International Soil Reference and Information Centre (ISRIC) show the fertile 'black belt' region of Alabama quite well.
+    </Caption> 
+  </Figure>
+
+</Block>
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <p>
+     The Black Belt's crescent shape is captured in a natural-color image by the Moderate Resolution Imaging Spectroradiometer (MODIS) on NASA’s Terra satellite. This image is a composition of segments from several images taken between 2015 and 2018, allowing for the removal of clouds and haze.  
+    </p>
+  </Prose>
+  <Figure style={{ flex: '0 0 auto'}}>
+    <Image
+      src={new URL('./blackbelt_tmo_2015-2018_lrg.jpg', import.meta.url).href}
+      style={{maxWidth: '800px', height: 'auto' }}
+    />
+    <Caption attrAuthor='Data.gov' attrUrl='https://earthobservatory.nasa.gov/images/92321/black-belt-prairie'>
+      Black Belt Prairie from MODIS.
+    </Caption>
+  </Figure>
+</Block>
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <p>
+     The region's rich soil played a pivotal role in shaping the region's history and demographics. This fertile land transformed the area into an agricultural powerhouse, making it a cornerstone of the cotton economy, heavily reliant on enslaved African American labor. After the Civil War, many African Americans remained in the area, working as sharecroppers and tenant farmers. The region became a significant cultural and political area, particularly noted for its role in the civil rights movement. Despite its agricultural legacy, the Black Belt has faced economic and social challenges, including poverty and limited access to education and healthcare, which continue to impact its predominantly African American population.
+    </p>
+  </Prose>
+  <Figure style={{ flex: '0 0 auto', marginLeft: '5px' }}>
+    <Image
+      src={new URL('./Black_cotton_farming_family.jpg', import.meta.url).href}
+      style={{ maxWidth: '100%', height: 'auto' }}
+    />
+  </Figure> 
+</Block>
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <Image
+        src={new URL('./BB_OlderPopulation.png', import.meta.url).href}
+        style={{ width: '30%', height: 'auto' }}
+    />
+    <p style={{ flex: '1' }}>
+      Analyzing Social Vulnerability Index (SVI) data from the CDC between 2000 and 2022 shows a concerning demographic shift: the younger generation, including those as young as 17, is increasingly moving out of the region, leaving behind an aging population, particularly those aged 65 and above. A linear trend is observed, with color coding representing the slope of this shift. This trend exacerbates the region's vulnerabilities, as the older population becomes more isolated and dependent. 
+    </p>
+    <Image
+        src={new URL('./BB_Youngerpopulation.png', import.meta.url).href}
+        style={{ width: '30%', height: 'auto' }}
+    />
+  </Prose>
+</Block>
+
+{/*
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ flex: '1', paddingRight: '1px', textAlign: 'justify' }}>
+    <p>
+      The region is now facing a significant new challenge: climate change. As global temperatures rise, extreme weather events like heatwaves are becoming increasingly frequent and severe. This is particularly concerning for areas where many residents, especially older adults, rely on outdoor agricultural work. Data from the MERRA-2 climate extreme indices dataset reveal troubling trends, showing changes in temperature extremes. Indices such as Cool Nights (TN10P) and Warm Nights (TN90P) track the frequency of days with nighttime temperatures falling below the 10th percentile or exceeding the 90th percentile. Similarly, Cool Days (TX10P) and Warm Days (TX90P) monitor daytime temperature extremes. Analyzing these indices from 1980 to 2023 uncovers a clear pattern of rising temperatures, with an increasing number of warm days and nights, highlighting the escalating climate challenges facing the region.
+    </p>
+  </Prose>
+</Block>
+*/}
+
+<ScrollytellingBlock>
+  <Chapter
+   center={[-86.71,33.10]}
+   zoom={6}
+   datasetId='svi-overall'
+   layerId='social-vulnerability-index-overall'
+   datetime='2016-01-01' 
+  >
+  ## Climate Extremes in the Black Belt Region
+    Alabama's Black Belt counties face escalating climate challenges. MERRA-2 data from 1980 to 2023 reveals significant shifts in temperature extremes. The region is experiencing an increase in warm days and nights (TX90P, TN90P) and a decrease in cool days and nights (TX10P, TN10P). These changes pose particular risks for the area's agricultural workforce and older residents, highlighting the growing impact of climate change on the region. 
+  </Chapter>
+
+  <Chapter
+   center={[-88.247405, 32.022218]}
+   zoom={8}
+   datasetId='svi-overall'
+   layerId='social-vulnerability-index-overall'
+   datetime='2016-01-01' 
+  >
+    ## Choctaw County
+    <Figure>
+      <Image
+      src={new URL('./BB_trends_Choctaw.png', import.meta.url).href}
+      />
+    <Caption attrAuthor=''>
+    Significant Trends in Climate Extremes from MERRA-2 (1980-2023): Slope Analysis (p < 0.1)
+    </Caption>
+    </Figure>
+  </Chapter>
+
+  <Chapter
+   center={[-86.510817,31.718222]}
+   zoom={8}
+   datasetId='svi-overall'
+   layerId='social-vulnerability-index-overall'
+   datetime='2016-01-01' 
+  >
+    ## Butler County
+    <Figure>
+      <Image
+      src={new URL('./BB_trends_Butler.png', import.meta.url).href}
+      />
+    <Caption attrAuthor=''>
+    Significant Trends in Climate Extremes from MERRA-2 (1980-2023): Slope Analysis (p < 0.1)
+    </Caption>
+    </Figure>
+  </Chapter>
+
+  <Chapter
+   center={[-87.927908, 33.280585]}
+   zoom={8}
+   datasetId='svi-overall'
+   layerId='social-vulnerability-index-overall'
+   datetime='2016-01-01' 
+  >
+      ## Pickens County
+    <Figure>
+      <Image
+      src={new URL('./BB_trends_Pickens.png', import.meta.url).href}
+      />
+    <Caption attrAuthor=''>
+    Significant Trends in Climate Extremes from MERRA-2 (1980-2023): Slope Analysis (p < 0.1)
+    </Caption>
+    </Figure>
+  </Chapter>
+
+  <Chapter
+   center={[-87.595494,32.205595]}
+   zoom={8}
+   datasetId='svi-overall'
+   layerId='social-vulnerability-index-overall'
+   datetime='2016-01-01' 
+  >
+      ## Marengo County
+    <Figure>
+      <Image
+      src={new URL('./BB_trends_Marengo.png', import.meta.url).href}
+      />
+    <Caption attrAuthor=''>
+    Significant Trends in Climate Extremes from MERRA-2 (1980-2023): Slope Analysis (p < 0.1)
+    </Caption>
+    </Figure>
+  </Chapter>
+</ScrollytellingBlock>
+
+
+{/*
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <Image
+        src={new URL('./BB_IncreasingWarmNights.png', import.meta.url).href}
+        style={{ width: '30%', height: 'auto' }}
+        alt="Increasing Warm Nights"
+    />
+    <p style={{ flex: '1' }}>
+      The increasing occurrences of warm days and warm nights are significantly impacting the counties within Alabama's Black Belt. The colorbar illustrates the slope of the linear trend. 
+    </p>
+    <Image
+        src={new URL('./BB_IncreasingWarmDays.png', import.meta.url).href}
+        style={{ width: '30%', height: 'auto' }}
+        alt="Increasing Warm Days"
+    />
+  </Prose>
+</Block>
+*/}
+
+{/*
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <Image
+        src={new URL('./BB_DecreasingCoolDays.png', import.meta.url).href}
+        style={{ width: '30%', height: 'auto' }}
+        alt="Increasing Warm Nights"
+    />
+    <p style={{ flex: '1' }}>
+      Concurrently, the decreasing occurrences of cool days and cool nights are also affecting the region. 
+    </p>
+    <Image
+        src={new URL('./BB_DecreasingCoolNights.png', import.meta.url).href}
+        style={{ width: '30%', height: 'auto' }}
+        alt="Increasing Warm Days"
+    />
+  </Prose>
+</Block>
+*/}
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <p>
+      Agriculture remains the backbone of the Black Belt's economy, with many older adults working in the fields. This reliance on an aging workforce is concerning, particularly as the physical demands of farming intensify with rising temperatures. In Sumter County, the number of farm operators aged 55 and above is increasing, reflecting a broader national trend where the average age of U.S. farm producers has risen to 58.1 years by 2022.
+    </p>
+  </Prose>
+  <Figure style={{ flex: '0 0 auto'}}>
+    <Image
+      src={new URL('./BB_AgeOperators_Sumter.png', import.meta.url).href}
+      style={{ maxWidth: '800px', height: 'auto' }}
+    />
+  </Figure> 
+</Block>
+
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <p>
+     Additionally, outdoor occupations such as transportation and construction have become crucial sources of income and have shown growth over the past few years. Data from the U.S. Census Bureau, which examines the number of establishments by employment category in counties like Choctaw and Butler, underscores the economic importance of these sectors.
+    </p>
+  </Prose>
+  <Figure style={{ flex: '0 0 auto'}}>
+    <Image
+      src={new URL('./BB_Estab_AL.png', import.meta.url).href}
+      style={{ maxWidth: '800px', height: 'auto' }}
+    />
+  </Figure> 
+</Block>
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ textAlign: 'justify', display: 'flex', alignItems: 'center' }}>
+    <p>
+     The combination of rising temperatures and an older workforce underscores the urgent need for adaptive strategies to protect both the health of the population and the viability of these economic sectors.Addressing these intertwined challenges requires targeted policies and investments in climate resilience measures. By enhancing education, healthcare, and job opportunities, along with adopting sustainable agricultural practices, the Black Belt can work towards a more resilient and prosperous future in the face of climate change. 
+     ### To mitigate heat-related risks, several safeguards can be implemented:
+     - Improved Access to Cooling Centers: Establishing more cooling centers in rural areas can provide relief during extreme heat events.
+     - Health Monitoring Programs: Implementing regular health check-ups for older adults working in agriculture can help prevent heat-related illnesses.
+     - Education and Training: Providing training on heat safety and recognizing symptoms of heat stress can empower workers to take preventive actions.
+     - Flexible Work Schedules: Adjusting work hours to cooler parts of the day can reduce exposure to extreme heat.
+    </p>
+  </Prose>
+</Block>
+
+<Block style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', margin: '0 auto', width: '80%' }}>
+  <Prose style={{ flex: '1', paddingRight: '20px', textAlign: 'justify' }}>
+    <p>
+     ### Data Access
+     * [NASA Description for MERRA-2 Climate Indices ](https://search.earthdata.nasa.gov/search/granules?p=C1949649168-GES_DISC&pg[0][v]=f&pg[0][gsk]=-start_date&q=MERRA-2%20extremes&tl=1724265744.288!3!!/)
+     * [CDC/ATSDR SVI Data and Documentation Download | Place and Health | ATSDR](https://www.atsdr.cdc.gov/placeandhealth/svi/data_documentation_download.html)
+     * [United States Department of Agriculture (USDA) | National Agricultural Statistics Service (NASS) | Census](https://www.nass.usda.gov/)
+     * [Census Bureau Data | Occupation](https://www.census.gov/topics/employment/industry-occupation.html)]
+    </p>
+    <p>
+     **Editor**: Maheshwari Neelam and Derek Koehl; 
+     **Developers**: Andrew Blackford, Trent Cowan, Jerika Christman, Brian Freitag, and Aaron Kaulfus ;
+     **Science and Content Contributors**: Maheshwari Neelam and Udaysankar Nair;
+     **Acknowledgements**: All individuals dedicated to Environmental Justice ;
+     **Questions / Feedback (email address)**: maheshwari.neelam@nasa.gov
+    </p>
+    <p>
+     #### Additional Resources
+     * https://blogs.edf.org/growingreturns/2023/08/02/heat-threat-for-farmworkers/ 
+     * https://www.thenation.com/article/society/black-farmers-pigford-debt/
+     * https://foodprint.org/issues/black-land-loss-in-the-united-states/
+     * https://inthesetimes.com/article/black-farmers-stress-debt-land-loss-racism-mental-health-crisis
+    </p>
+  </Prose>
+</Block>
+
+
+


### PR DESCRIPTION
**NOTE: DO NOT MERGE till we get the go ahead from BE**

This is to add back the soil texture dataset and Black Belt story we intitially held back when we bumped veda-config to use veda-ui v5.8.0 (related PR https://github.com/NASA-IMPACT/veda-config/pull/460)! We removed because this dataset wasn't in openveda prod - it is not but there are still some ongoing stories related to it! - Tagging BE alongside this PR
