### PR TITLE
Node.js version in 'docs/SETUP.md' is not in sync with '.nvmrc'

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -13,7 +13,7 @@ git submodule update --init --recursive
 
 To set up the development environment for this website, you'll need to install the following on your system:
 
-- [Node](http://nodejs.org/) (see version in [.nvmrc](./.nvmrc)) (To manage multiple node versions we recommend [nvm](https://github.com/creationix/nvm))
+- [Node](http://nodejs.org/) (see version in [.nvmrc](../.nvmrc)) (To manage multiple node versions we recommend [nvm](https://github.com/creationix/nvm))
 - [Yarn](https://yarnpkg.com/) Package manager
 
 If you use [`nvm`](https://github.com/creationix/nvm), activate the desired Node version:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -4,14 +4,16 @@ This repo contains all the content and configuration needed to setup your own in
 
 The `veda-config` relies on the `veda-ui` submodule.  
 Use `--recursive` flag when cloning `veda-config`, or initialize the submodules with:
+
 ```
 git submodule update --init --recursive
 ```
 
 ## Requirements
+
 To set up the development environment for this website, you'll need to install the following on your system:
 
-- [Node](http://nodejs.org/) v16 (To manage multiple node versions we recommend [nvm](https://github.com/creationix/nvm))
+- [Node](http://nodejs.org/) (see version in [.nvmrc](./.nvmrc)) (To manage multiple node versions we recommend [nvm](https://github.com/creationix/nvm))
 - [Yarn](https://yarnpkg.com/) Package manager
 
 If you use [`nvm`](https://github.com/creationix/nvm), activate the desired Node version:
@@ -34,11 +36,13 @@ Then, setup the project by running the command below.
 ## Usage
 
 ### Config files
+
 Configuration is done using [dot.env](https://parceljs.org/features/node-emulation/#.env-files) files.
 
 These files are used to simplify the configuration of the app and should not contain sensitive information.
 
 Copy the `.env.local-sample` to `.env.local` to add your configuration variables.
+
 ```sh
 cp .env.local-sample .env.local
 ```
@@ -50,11 +54,12 @@ Get your Mapbox access token from Mapbox Dashboard. Put the key in `.env.local` 
 ## Running the app
 
 To preview the app use:
+
 ```
 yarn serve
 ```
 
-This will start the app and make it available at http://localhost:9000.
+This will start the app and make it available at <http://localhost:9000>.
 
 If the application is not working properly or erroring when it starts, try cleaning the cache with `yarn clean`.  
 If the errors persist [open an issue](https://github.com/NASA-IMPACT/veda-config/issues/new) with the problem description.


### PR DESCRIPTION
The Node.js version in `docs/SETUP.md` is not in sync with the content of `.nvmrc` (v16 vs. v20). With this change, the document now refers directly to `.nvmrc`, which helps avoid forgetting to update the Node.js version in multiple places in the future. This also introduces minor Markdown formatting.

How to test: open `docs/SETUP.md`, it should link to `.nvmrc` file instead of display the outdate Node.js version.