### PR TITLE
fix: release action

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        ref: ${{ github.event.client_payload.ref }}
+        ref: develop
         fetch-depth: 0
     - name: Use Node.js ${{ env.NODE }}
       uses: actions/setup-node@v1


### PR DESCRIPTION
The ref should have been hard coded as `develop`, not the payload from the dispatch action. (This is why https://github.com/NASA-IMPACT/veda-config/actions/runs/12870788863 this action failed - it checked out to main instead of develop)