### PR TITLE
feat: update actions/cache to v4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ env.NODE }}
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-node-modules
         with:
           path: |
@@ -65,7 +65,7 @@ jobs:
           node-version: ${{ env.NODE }}
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-node-modules
         with:
           path: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ env.NODE }}
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-node-modules
         with:
           path: |
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
 
       - name: Cache dist
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-dist
         with:
           path: dist
@@ -75,7 +75,7 @@ jobs:
           submodules: recursive
 
       - name: Restore node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-node-modules
         with:
           path: |
@@ -84,7 +84,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
 
       - name: Restore dist cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-dist
         with:
           path: dist


### PR DESCRIPTION
### Reason
TLDR, we noticed the `checks workflow` breaking when testing `veda-data` GH actions which create `veda-config` PRs. 
- https://github.com/NASA-IMPACT/veda-data/actions/runs/13399992067/job/37428902977
- https://github.com/NASA-IMPACT/veda-config/actions/runs/13400267419

From the actions/cache [README](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes): We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before February 1st, 2025. (Upgrade instructions below).


[From the GitHub Blog](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)

> Starting February 1st, 2025, Actions’ cache storage will move to a new architecture, as a result we are closing down v1-v2 of actions/cache. In conjunction, all previous versions of the [@actions/cache package](https://github.com/actions/toolkit/blob/main/packages/cache/README.md) (prior to 4.0.0) in actions/toolkit will be closing down. The action and cache package will be fully retired on March 1st.
>
> If users run workflows that call the retired versions after March 1st, 2025, the workflows will fail. Announcements have been posted in the [actions/cache](https://github.com/actions/cache/discussions/categories/announcements) and [actions/toolkit](https://github.com/actions/toolkit/discussions/categories/announcements) repositories with additional information on the migration. Note that this does not affect GitHub Enterprise Server customers, you can continue to use all versions without failure.
>
> Brownouts:
To raise awareness of the upcoming deprecation, we have scheduled brownouts for the following dates/times, builds that are scheduled to run during the brownout periods will fail.
February 4, 5pm – 6pm UTC
February 11, 3pm – 7pm UTC
February 18, 2pm – 10pm UTC