### PR TITLE
update two hyperlinks. And change verbage from TOPS to "open source"

### DIFF
--- a/overrides/about.mdx
+++ b/overrides/about.mdx
@@ -17,12 +17,12 @@ description: "Visualization, Exploration, and Data Analysis (VEDA): Scalable and
 
     ## Commitment to Open Science
 
-    In alignment with NASA's [Transform to Open Science](https://science.nasa.gov/open-science/transform-to-open-science) (TOPS) initiative, VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
+    In alignment with NASA's [Open Science initiative](https://science.nasa.gov/open-science/), VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
 
     The different repositories of the VEDA project are all open and can be freely browsed:
     - [veda-ui](https://github.com/NASA-IMPACT/veda-ui) (the web application)
     - [veda-config](https://github.com/NASA-IMPACT/veda-config) (content storage)
-    - [veda-data-pipelines](https://github.com/NASA-IMPACT/veda-data-pipelines) (data transformation and ingest)
+    - [veda-data](https://github.com/NASA-IMPACT/veda-data) (data transformation and ingest)
     - [veda-backend](https://github.com/NASA-IMPACT/veda-backend) (backend stac and tiler)
     
     The full list can be found [here](https://github.com/orgs/NASA-IMPACT/repositories?language=&q=veda-&sort=&type=all).

--- a/overrides/about.mdx
+++ b/overrides/about.mdx
@@ -17,7 +17,7 @@ description: "Visualization, Exploration, and Data Analysis (VEDA): Scalable and
 
     ## Commitment to Open Science
 
-    In alignment with NASA's [Open Science Science initiative](https://science.nasa.gov/open-science/) (OSSI), VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
+    In alignment with NASA's [Open Science Science Initiative](https://science.nasa.gov/open-science/) (OSSI), VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
 
     The different repositories of the VEDA project are all open and can be freely browsed:
     - [veda-ui](https://github.com/NASA-IMPACT/veda-ui) (the web application)

--- a/overrides/about.mdx
+++ b/overrides/about.mdx
@@ -17,7 +17,7 @@ description: "Visualization, Exploration, and Data Analysis (VEDA): Scalable and
 
     ## Commitment to Open Science
 
-    In alignment with NASA's [Open Science initiative](https://science.nasa.gov/open-science/), VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
+    In alignment with NASA's [Open Science Science initiative](https://science.nasa.gov/open-science/) (OSSI), VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
 
     The different repositories of the VEDA project are all open and can be freely browsed:
     - [veda-ui](https://github.com/NASA-IMPACT/veda-ui) (the web application)

--- a/overrides/about.mdx
+++ b/overrides/about.mdx
@@ -17,7 +17,7 @@ description: "Visualization, Exploration, and Data Analysis (VEDA): Scalable and
 
     ## Commitment to Open Science
 
-    In alignment with NASA's [Open Science Science Initiative](https://science.nasa.gov/open-science/) (OSSI), VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
+    In alignment with NASA's [Open Source Science Initiative](https://science.nasa.gov/open-science/) (OSSI), VEDA believes that a commitment to open source is an important aspect of creating and maintaining high-quality software and science. Open source code provided by VEDA as part of this initiative allows for collaboration and transparency, to promote better solutions and more robust code.
 
     The different repositories of the VEDA project are all open and can be freely browsed:
     - [veda-ui](https://github.com/NASA-IMPACT/veda-ui) (the web application)

--- a/overrides/about.mdx
+++ b/overrides/about.mdx
@@ -13,7 +13,7 @@ description: "Visualization, Exploration, and Data Analysis (VEDA): Scalable and
     - a tool by which users can visually explore and localize data, and perform independent analysis; data-driven stories that are exportable in multiple formats;
     - and a situational awareness system that brings together Earth observation datasets such as greenhouse gasses, air quality, and sea level rise, among others.
 
-    As an interactive visual interface for storytelling, the dashboard provides a number of capabilities including sharing and interacting with datasets and their respective stories. Through visualizations, trend analyses, and comparative analyses of datasets, users can explore the applications and implications of those data. The VEDA Dashboard aims to reduce the barrier to entry of NASA of the Earth science data and enable faster science – one of the goals of the NASA open-source science initiative. Please submit any feedback or questions using the Feedback button in the top right of the dashboard.
+    As an interactive visual interface for storytelling, the dashboard provides a number of capabilities including sharing and interacting with datasets and their respective stories. Through visualizations, trend analyses, and comparative analyses of datasets, users can explore the applications and implications of those data. The VEDA Dashboard aims to reduce the barrier to entry of NASA of the Earth science data and enable faster science – one of the goals of the NASA open-source science initiative. Please submit any feedback or questions using the "Contact Us" button in the top right of the dashboard.
 
     ## Commitment to Open Science
 


### PR DESCRIPTION
1.) Updated two hyperlinks. One was broken and the other was to a deprecated repo.
2.) Changed verbage from TOPS to "Open source".   I cannot find any working hyperlink/webpage which will take you to a place where TOPS can be discussed other than here https://www.nasa.gov/centers-and-facilities/marshall/marshall-science-research-and-projects/the-transform-to-open-science-tops-project-office-has-been-established-here-at-marshall/. But this webpage also contains the same broken link that we did.   So I updated the link to be to the NASA Open Source webpage.

