### PR TITLE
Remove US Govt banner

### DIFF
--- a/.env
+++ b/.env
@@ -34,6 +34,3 @@ CUSTOM_SCRIPT_SRC='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.
 CUSTOM_SCRIPT_ID='_fed_an_ua_tag'
 
 ENABLE_COOKIE_CONSENT_FORM = 'TRUE'
-
-ENABLE_USWDS_PAGE_HEADER = 'TRUE'
-

--- a/veda.config.js
+++ b/veda.config.js
@@ -1,19 +1,3 @@
-const defaultGuidance = {
-  left: {
-    title: 'Official websites use .gov',
-    text: 'A **.gov** website belongs to an official government organization in the United States.',
-    iconAlt: 'Dot gov icon',
-    icon: '/img/icon-dot-gov.svg'
-  },
-  right: {
-    title: 'Secure .gov websites use HTTPS',
-    text: "A **lock icon** or **https://** means you've safely connected to the .gov website. Share sensitive information only on official, secure websites.",
-    iconAlt: 'HTTPS icon',
-    icon: '/img/icon-https.svg'
-  }
-};
-
-
 module.exports = {
   /**
    * Glob path for the datasets.
@@ -42,17 +26,5 @@ module.exports = {
   cookieConsentForm: {
     title: "Cookie Consent",
     copy: "We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our [Privacy Policy](https://www.nasa.gov/privacy/#cookies).",
-  },
-  banner: {
-    headerText: 'An official website of the United States government',
-    headerActionText: "Here's how you know",
-    ariaLabel: 'Banner for official government website',
-    flagImgSrc: '/img/us_flag_small.png',
-    flagImgAlt: 'US flag',
-    leftGuidance: defaultGuidance.left,
-    rightGuidance: defaultGuidance.right,
-    className: '',
-    defaultIsOpen: false,
-    contentId: 'gov-banner-content'
-  },
+  }
 };


### PR DESCRIPTION
# Description

- Remove the banner because earthdata.nasa.gov doesn't have it yet
- Disable USWDS header