### PR TITLE
update endpoint for titiler-cmr

### DIFF
--- a/datasets/GPM_3IMERGDF.data.mdx
+++ b/datasets/GPM_3IMERGDF.data.mdx
@@ -22,7 +22,7 @@ layers:
   - id: GPM_3IMERGDF.v07
     type: cmr
     stacCol: GPM_3IMERGDF
-    tileApiEndpoint: "https://dev-titiler-cmr.delta-backend.com/WebMercatorQuad/tilejson.json"
+    tileApiEndpoint: "https://staging.openveda.cloud/api/titiler-cmr/WebMercatorQuad/tilejson.json"
     name: GPM IMERG Final Precipitation L3 1 day 0.1 degree x 0.1 degree
     description: "GPM Level 3 IMERG Final Daily 10 x 10 km (GPM_3IMERGDF) accumulated precipitation"
     time_density: day

--- a/datasets/hls_2.0.data.mdx
+++ b/datasets/hls_2.0.data.mdx
@@ -40,7 +40,7 @@ layers:
     type: cmr
     stacCol: HLSL30_2.0
     stacApiEndpoint: "https://cmr.earthdata.nasa.gov/stac/LPCLOUD"
-    tileApiEndpoint: "https://dev-titiler-cmr.delta-backend.com/WebMercatorQuad/tilejson.json"
+    tileApiEndpoint: "https://staging.openveda.cloud/api/titiler-cmr/WebMercatorQuad/tilejson.json"
     name: "HLS Landsat 8/9 True Color Composite"
     description: "True color composite image from Landsat 8/9 bands B04, B03, B02"
     time_density: day


### PR DESCRIPTION
Thanks to @hrodmn and @botanical we now have a veda-deploy deployment and staging.openveda.cloud endpoint for titiler-cmr. This PR just updates the existing configs which use titiler-cmr.