### PR TITLE
chore: Bump the Fire Event Explorer version to include paging downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stream-browserify": "^3.0.0"
   },
   "dependencies": {
-    "@dsio/wildfire-explorer": "0.4.5",
+    "@dsio/wildfire-explorer": "0.4.6",
     "@parcel/transformer-sass": "^2.13.3",
     "@trussworks/react-uswds": "^9.1.0",
     "@uswds/uswds": "^3.8.1",


### PR DESCRIPTION
We recently merged an improvement wrt downloads in the Fire Event Explorer and bumped the version to v0.4.6. The new change includes paging the service endpoints when downloading fire data, so to avoid big payloads in cases where there are long running fires.

Test the change:

1. [Open the fire event explorer](https://deploy-preview-882--visex.netlify.app/tools/fire-event-explorer)
2. Select a fire
3. Download the data for the selected fire -> In the Network Tab there will be multiple smaller requests fetching a max of 30 features per request