### PR TITLE
fix: use correct url for titiler-multidim endpoint!

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ API_RASTER_ENDPOINT='https://openveda.cloud/api/raster'
 
 # Endpoint for the STAC server. No trailing slash.
 API_STAC_ENDPOINT='https://openveda.cloud/api/stac'
-API_TITILER_MULTIDIM_ENDPOINT='https://staging.openveda.cloud/api/multidim/WebMercatorQuad/tilejson.json'
+API_TITILER_MULTIDIM_ENDPOINT='https://staging.openveda.cloud/api/titiler-multidim/WebMercatorQuad/tilejson.json'
 
 MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 


### PR DESCRIPTION
We aren't using titiler-multidim for any datasets right now but when we do we will need to have the correct URL set!

cc @maxrjones @jbusecke