### PR TITLE
chore: Bump the Fire Event Explorer to v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stream-browserify": "^3.0.0"
   },
   "dependencies": {
-    "@dsio/wildfire-explorer": "0.5.0",
+    "@dsio/wildfire-explorer": "0.5.1",
     "@parcel/transformer-sass": "^2.13.3",
     "@trussworks/react-uswds": "^9.1.0",
     "@uswds/uswds": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stream-browserify": "^3.0.0"
   },
   "dependencies": {
-    "@dsio/wildfire-explorer": "0.4.9",
+    "@dsio/wildfire-explorer": "0.5.0",
     "@parcel/transformer-sass": "^2.13.3",
     "@trussworks/react-uswds": "^9.1.0",
     "@uswds/uswds": "^3.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,10 +73,10 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dsio/wildfire-explorer@0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@dsio/wildfire-explorer/-/wildfire-explorer-0.4.9.tgz#27859eb5862e3dfbaa9375253ddaaa7ebd94a8f5"
-  integrity sha512-od6L8Jx0OnYu7Xj3NQ3gQoRDxdT2aPu76xBT1C0fAdL4EIq72CRv9Ho4NodTHjunyqJzNfDSe3fF0Rd9Ijzt1g==
+"@dsio/wildfire-explorer@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@dsio/wildfire-explorer/-/wildfire-explorer-0.5.0.tgz#d8c1432587127d80114237c1af2409e95d329d5b"
+  integrity sha512-zqvTEJAclHo5V0pkyfdY5Z2/oNkMCVOr9h9grNNVnw19ThcQejSrcsKHY870a3Nz7LCtyM/hXWVWZsSYgOcMFQ==
   dependencies:
     "@deck.gl/extensions" "^9.1.4"
     "@deck.gl/react" "^9.1.4"


### PR DESCRIPTION
Bump the Fire Event Explorer to v0.5.0 to include pagination when selecting fire events (related issue: https://github.com/NASA-IMPACT/veda-ui/issues/1758