### PR TITLE
chore: Bump the Fire Event Explorer to v0.6.2

### DIFF
--- a/custom-pages/wildfire-explorer/atoms/toolStateAtom.ts
+++ b/custom-pages/wildfire-explorer/atoms/toolStateAtom.ts
@@ -1,6 +1,10 @@
 // @ts-ignore
 import { atomWithUrlValueStability } from '$veda-ui-scripts/utils/params-location-atom/atom-with-url-value-stability';
 
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const MONTH = 30 * DAY;
+
 const defaultToolState = {
   selectedEventId: null,
   windLayerType: null,
@@ -10,7 +14,7 @@ const defaultToolState = {
   showNewFirepix: false,
   viewMode: 'explorer',
   timeRange: {
-    start: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+    start: new Date(Date.now() - MONTH),
     end: new Date(),
   },
   viewState: {

--- a/custom-pages/wildfire-explorer/atoms/toolStateAtom.ts
+++ b/custom-pages/wildfire-explorer/atoms/toolStateAtom.ts
@@ -17,6 +17,7 @@ const defaultToolState = {
     start: new Date(Date.now() - MONTH),
     end: new Date(),
   },
+  selectedDuration: { label: '1 month', value: MONTH },
   viewState: {
     longitude: -95.7129,
     latitude: 37.0902,
@@ -44,6 +45,7 @@ export const toolStateAtom = atomWithUrlValueStability<any>({
           start: new Date(parsed.timeRange?.start || defaultToolState.timeRange.start),
           end: new Date(parsed.timeRange?.end || defaultToolState.timeRange.end),
         },
+        selectedDuration: parsed.selectedDuration || defaultToolState.selectedDuration,
         viewState: {
           longitude: parsed.viewState?.longitude ?? defaultToolState.viewState.longitude,
           latitude: parsed.viewState?.latitude ?? defaultToolState.viewState.latitude,
@@ -71,6 +73,7 @@ export const toolStateAtom = atomWithUrlValueStability<any>({
           start: value.timeRange.start.toISOString(),
           end: value.timeRange.end.toISOString(),
         },
+        selectedDuration: value.selectedDuration,
         viewState: {
           longitude: value.viewState?.longitude,
           latitude: value.viewState?.latitude,
@@ -80,7 +83,6 @@ export const toolStateAtom = atomWithUrlValueStability<any>({
           padding: value.viewState?.padding,
         },
       };
-
       return JSON.stringify(serializable);
     } catch (error) {
       console.warn('Failed to serialize tool state:', error);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stream-browserify": "^3.0.0"
   },
   "dependencies": {
-    "@dsio/wildfire-explorer": "0.6.0",
+    "@dsio/wildfire-explorer": "0.6.2",
     "@parcel/transformer-sass": "^2.13.3",
     "@trussworks/react-uswds": "^9.1.0",
     "@uswds/uswds": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stream-browserify": "^3.0.0"
   },
   "dependencies": {
-    "@dsio/wildfire-explorer": "0.5.1",
+    "@dsio/wildfire-explorer": "0.6.0",
     "@parcel/transformer-sass": "^2.13.3",
     "@trussworks/react-uswds": "^9.1.0",
     "@uswds/uswds": "^3.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,10 +73,10 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dsio/wildfire-explorer@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@dsio/wildfire-explorer/-/wildfire-explorer-0.6.0.tgz#1c4c8dc3781326e797876632a7ba1ce267bc3dcc"
-  integrity sha512-PP4qrlrb14zaLSBrCn+JF2dDJa2/CBrRVKak2PyKRWkpd6qvvcA3JXFb+UirnmW2jYyt9JXQaEInR96PhOmLsQ==
+"@dsio/wildfire-explorer@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@dsio/wildfire-explorer/-/wildfire-explorer-0.6.2.tgz#5ce110e485171427817f8cd349a31393423b96c5"
+  integrity sha512-Ne46L2ADhiSDGpTHeuseBZ6jVAJxnZIiFG1+4YHEb3imgYJLYixfGIsPn8t3VsGxQk0GlWoWf8kmV/BKt4ojSA==
   dependencies:
     "@deck.gl/extensions" "^9.1.4"
     "@deck.gl/react" "^9.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,10 +73,10 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dsio/wildfire-explorer@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@dsio/wildfire-explorer/-/wildfire-explorer-0.5.0.tgz#d8c1432587127d80114237c1af2409e95d329d5b"
-  integrity sha512-zqvTEJAclHo5V0pkyfdY5Z2/oNkMCVOr9h9grNNVnw19ThcQejSrcsKHY870a3Nz7LCtyM/hXWVWZsSYgOcMFQ==
+"@dsio/wildfire-explorer@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@dsio/wildfire-explorer/-/wildfire-explorer-0.6.0.tgz#1c4c8dc3781326e797876632a7ba1ce267bc3dcc"
+  integrity sha512-PP4qrlrb14zaLSBrCn+JF2dDJa2/CBrRVKak2PyKRWkpd6qvvcA3JXFb+UirnmW2jYyt9JXQaEInR96PhOmLsQ==
   dependencies:
     "@deck.gl/extensions" "^9.1.4"
     "@deck.gl/react" "^9.1.4"


### PR DESCRIPTION
Related issue: https://github.com/NASA-IMPACT/veda-ui/issues/1778

1. Introduce a simplified DateRangeSelector w/o the histogram
2. Add a datetime param to the API calls when fetching vector tiles
