### PR TITLE
chore: update paths based on monorepo changes in veda-ui 

### DIFF
--- a/.veda/veda
+++ b/.veda/veda
@@ -41,7 +41,7 @@ if (inputCmd === '--info') {
 const rootDir = path.join(__dirname, '../');
 
 const parentThemeFile = path.join(__dirname, 'styles/_uswds-theme.scss');
-const submoduleThemeFile = path.join(__dirname, '.veda/ui/app/scripts/styles/_uswds-theme.scss');
+const submoduleThemeFile = path.join(__dirname, '.veda/ui/packages/veda-ui/src/styles/_uswds-theme.scss');
 let originalSubmoduleTheme = '';
 
 // Temporarily swap the USWDS theme file from the veda-ui with the one from veda-config

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "./.veda/ui/node_modules/react",
     "@mdx-js/react": "./.veda/ui/node_modules/@mdx-js/react",
     "$veda-ui": "./.veda/ui/node_modules",
-    "$veda-ui-scripts": "./.veda/ui/app/scripts"
+    "$veda-ui-scripts": "./.veda/ui/packages/veda-ui/src"
   },
   "parcelIgnore": [
     ".*/meta/"


### PR DESCRIPTION
This PR updates veda-config to align with the path changes introduced in veda-ui (see https://github.com/NASA-IMPACT/veda-ui/pull/1898). Once that PR is merged and released, the corresponding paths in this repository must be updated to remain compatible.

The same path updates are also required in:

- veda-config-ghg: https://github.com/US-GHG-Center/veda-config-ghg
- veda-config-eic: https://github.com/NASA-IMPACT/veda-config-eic (probably optional, as this repo may be replaced soon by next-earth-gov launch and its veda-ui submodule has not been updated in ~9 months)