### PR TITLE
ci: pin GitHub Actions to SHA digests (fix zizmor unpinned-uses)

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: recursive
         ref: develop
         fetch-depth: 0
     - name: Use Node.js ${{ env.NODE }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ env.NODE }}
 
@@ -50,7 +50,7 @@ jobs:
         cd -
     - name: Create Pull Request
       id: making-pr
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
       with:
         commit-message: "Update UI to ${{ env.VERSION }}"
         title: "ci: Update submodule to version ${{ env.VERSION }}"
@@ -58,7 +58,7 @@ jobs:
         base: develop
         branch: ci-update-${{ env.VERSION }}
     - name: Notify release through Slack
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
         webhook-type: incoming-webhook

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,22 +23,22 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@3d86a7cc43670094ac248017207be0295edbc31d # 0.8.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Use Node.js ${{ env.NODE }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE }}
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-node-modules
         with:
           path: |
@@ -55,17 +55,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Use Node.js ${{ env.NODE }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE }}
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-node-modules
         with:
           path: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,22 +23,22 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@3d86a7cc43670094ac248017207be0295edbc31d # 0.8.0
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Use Node.js ${{ env.NODE }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE }}
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-node-modules
         with:
           path: |
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
 
       - name: Cache dist
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-dist
         with:
           path: dist
@@ -70,12 +70,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Restore node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-node-modules
         with:
           path: |
@@ -84,14 +84,14 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
 
       - name: Restore dist cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-dist
         with:
           path: dist
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.workflow }}-${{ github.sha }}
 
       - name: Use Node.js ${{ env.NODE }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE }}
 
@@ -102,7 +102,7 @@ jobs:
           cp deploy/dashboard/index.html deploy/index.html
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: "veda-dashboard-prod-deployment"
@@ -113,6 +113,6 @@ jobs:
           aws s3 sync ./deploy s3://${{ env.DEPLOY_BUCKET_PROD }} --cache-control max-age=30,must-revalidate,s-maxage=604800 --delete
 
       - name: Invalidate CloudFront cache
-        uses: oneyedev/aws-cloudfront-invalidation@v1
+        uses: oneyedev/aws-cloudfront-invalidation@11968a27b893903ac1f4290760f50865e0037260 # v1
         with:
           distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_PROD }}


### PR DESCRIPTION
Pins all GitHub Actions workflow steps to full SHA digests, eliminating the `unpinned-uses` supply-chain risk identified by zizmor (22 findings fixed).

Closes #972

### Recommended next steps

1. Enable Dependabot for `github-actions` to keep pinned SHAs up-to-date automatically (a companion PR may be opened for this repo).
2. Add [zizmor-action](https://github.com/zizmorcore/zizmor-action?tab=readme-ov-file#usage-with-github-advanced-security-recommended) for continuous workflow security scanning in CI.

---
_Generated by [ds-security-scanning](https://github.com/developmentseed/ds-security-scanning) zizmor-cli-unpinned-uses_