### PR TITLE
chore: remove map block from recently unpublished Disasters story

### DIFF
--- a/stories/air-quality-so2-volcanoes.stories.mdx
+++ b/stories/air-quality-so2-volcanoes.stories.mdx
@@ -76,22 +76,6 @@ taxonomy:
   </Chapter>
 </ScrollytellingBlock>
 
-<Block>
-  <Figure>
-    <iframe
-      width="100%"
-      height="100%"
-      style={{ aspectRatio: "70/50" }}
-      src="https://maps.disasters.nasa.gov/arcgis/apps/webappviewer/index.html?id=514e11b43f9b493c832c6520f653e523"
-      title="Volcanoes Around the World"
-      frameborder="0"
-
-    />
-    <Caption>
-      Locations of SO2 emissions, including volcanoes, around the world that NASA monitors.
-    </Caption>
-  </Figure>
-</Block>
 
 <Block>
   <Prose>


### PR DESCRIPTION
## Summary

The story [Monitoring Volcanic Sulfur Dioxide Emissions](https://www.earthdata.nasa.gov/dashboard/stories/so2-volcanoes) has a 404 error due to the Disasters NCCS servers being discontinued. This story is not expected to be re-published in the near future.

Therefore, we are removing this per recommendations from Disasters/Brian.

<img width="751" height="594" alt="image" src="https://github.com/user-attachments/assets/2f50ef97-d804-430f-89dc-15420eea657e" />

<img width="635" height="259" alt="image" src="https://github.com/user-attachments/assets/dd9ee6c0-6d76-486e-a3c8-c3d58db6dcb1" />
