### PR TITLE
Fix BAIS-2 Burned Area layer not previewing in Lahaina Fire story (#987)

### DIFF
--- a/datasets/lahaina-fire.data.mdx
+++ b/datasets/lahaina-fire.data.mdx
@@ -37,8 +37,8 @@ layers:
       - 20
     sourceParams:
       colormap_name: rdylbu_r
-      rescale: 
-        -0.5
+      rescale:
+        - -0.5
         - 1
       resampling: bilinear
       bidx: 1


### PR DESCRIPTION
## Fixes #987

### Problem
The `BAIS-2 Burned Area` (`hls-bais2-v2`) layer in the Lahaina Fire story returns no data when previewed.

As diagnosed by @anayeaye in the issue, the STAC item and COG exist and are valid — the bug is malformed YAML in the dataset MDX. The `rescale` value was written as:

```yaml
rescale: 
  -0.5
  - 1
```

Because the key value is empty and the first line (`-0.5`) is a bare scalar (no `- ` list prefix), YAML folds these lines into a single plain scalar string `"-0.5 - 1"`. The tiler then received `rescale=-0.5 - 1` and returned no data.

### Fix
Format `rescale` as a proper two-element list so the request sends `rescale=-0.5,1`:

```yaml
rescale:
  - -0.5
  - 1
```

This matches the working preview confirmed in the issue:
https://openveda.cloud/api/raster/cog/preview?url=s3://veda-data-store/hls-bais2-v2/Lahaina_BAIS2_2023-08-13.tif&colormap_name=rdylbu_r&rescale=-0.5,1&resampling=bilinear&nodata=-9999&assets=cog_default&bidx=1

### Verification
- Parsed the corrected frontmatter with `js-yaml`: `rescale` now loads as the array `[-0.5, 1]` (was the string `"-0.5 - 1"`).
- Scanned all 117 dataset/story MDX files for the same folded-scalar pattern (and any `rescale` string containing stray whitespace) — **no other occurrences found**. No STAC/data changes required.